### PR TITLE
Delete informal vocabulary encoding rules for CJ5

### DIFF
--- a/CantoboardFramework/Data/Rime/cangjie5.dict.yaml
+++ b/CantoboardFramework/Data/Rime/cangjie5.dict.yaml
@@ -26,13 +26,6 @@ encoder:
   exclude_patterns:
     - '^x.*$'
     - '^z.*$'
-  rules:
-    - length_equal: 2
-      formula: "AaAzBaBbBz"
-    - length_equal: 3
-      formula: "AaAzBaBzCz"
-    - length_in_range: [4, 10]
-      formula: "AaBzCaYzZz"
   tail_anchor: "'"
 ...
 日	a


### PR DESCRIPTION
Delete encoding rules which not exists in Regular CJ5