### PR TITLE
Clean up Yale Schema

### DIFF
--- a/CantoboardFramework/Data/Rime/yale.schema.yaml
+++ b/CantoboardFramework/Data/Rime/yale.schema.yaml
@@ -3,8 +3,8 @@
 
 schema:
   schema_id: yale
-  name: 耶魯拼音
-  version: "2020.11.26"
+  name: 耶魯–劉錫祥混合拼音
+  version: "2021.08.22"
   author:
     - sgalal <sgalal.me@outlook.com>
     - LeiMaau <leimaau@qq.com>
@@ -16,7 +16,7 @@ schema:
     - Bing Jeung <bing@ososo.io>
     - Ayaka Mikazuki <ayaka@mail.shn.hk>
 
-  description: 耶魯拼音
+  description: 耶魯–劉錫祥混合拼音
 
 switches:
   - name: ascii_mode
@@ -63,93 +63,95 @@ speller:
   delimiter: " '"
   algebra:
     # 取消下兩行註釋，支援疑影交替： ng- 通 Ø-，Ø- 通 ng-
-    #- derive/^ng([aeiou])/$1/
-    #- derive/^([aeiou])/ng$1/
+    - derive/^ng(?=[aeiou])//
+    - derive/^(?=[aeiou])/ng/
 
     # 取消下行註釋，支援泥來合流： n- 併入 l- ，如「你」讀若「理」
-    #- derive/^n(?!g)/l/
+    - derive/^n(?!g)/l/
 
-    # 取消下行註釋，支援圓唇輔音合口韻缺位： gw-, kw- 併入 g-, k- ，如「國」讀若「各」、「廓」讀若「確」
-    #- derive/^(g|k)w/$1/
+    # 取消下行註釋，支援圓唇輔音合口韻缺位： gwo-, kwo- 併入 go-, ko- ，如「國」讀若「各」、「廓」讀若「確」
+    - derive/^(g|k)w(?=o)/$1/
 
     # 取消下行註釋，支援獨立鼻音韻 ng 併入 m，如「吳」讀若「唔」
-    #- derive/^ng([123456])$/m$1/
-    
-    # 耶魯轉換成粵拼
-    - xform/^jyu/yu/
-    - xform/^j/y/
-    - xform/^z/j/
-    - xform/^c/ch/
-    - xform/oeng(\d)/eung$1/
-    - xform/oek(\d)/euk$1/
-    - xform/eoi(\d)/eui$1/
-    - xform/eon(\d)/eun$1/
-    - xform/eot(\d)/eut$1/
-    - xform/oe(\d)/eu$1/
-    - xform/aa(\d)/a$1/
-    
+    - derive/^ng(?=\d)/m/
+
+    - derive/^(?=[aeiou])/q/
+    - xform/jy?/y/
+    - derive/yu(?!ng|k)/y/
+    - erase/^y\d$/
+    - derive/aa/r/
+    - derive/oe|eo/eu/
+    - derive/aa(?=\d)/a/
+    - derive/z/j/
+    - derive/c/ch/
+
     # 常見錯誤拼音 幫助港式拼音使用者上手
     # 聲母
-    - derive/^ch/ts/ # e.g. 荃灣 Tsuen
-    - derive/^s/sh/ # e.g. 上環 Sheung
+    - derive/j/zh/ # e.g. 中 zhung
+    - derive/s/sh/ # e.g. 上環 Sheung
 
     # 韻母
-    - derive/am(\d)/um$1/ # e.g. 點心 Sum
-    - derive/am(\d)/om$1/ # e.g. 紅磡 Hom
-    
-    - derive/ou(\d)/o$1/ # e.g. 好 ho
-    - derive/h(\d)/$1/ # e.g. 野 yeh
-    
-    - derive/u(\w?\d)/oo$1/ # e.g. 美乎 Foo
-    
-    - derive/o(\d)/oh$1/ # e.g. 個 goh
-    - derive/o(\d)/or$1/ # e.g. 哥 gor
-    
-    - derive/eu(\w?\d)/u$1/ # e.g. 對 dui 春 chun
-    
-    - derive/i(\d)/ee$1/ # e.g. 以 yee
-    - derive/ei(\d)/ee$1/ # e.g. 李 lee
+    - derive/(?<!a)a(?=m|p)/u/ # e.g. 點心 Sum
+    - derive/(?<!a)a(?=m|p)/o/ # e.g. 紅磡 Hom
 
-    - derive/^yu(\w{0,2}\d)/yue$1/ # e.g. 元朗 Yuen
-    - derive/([^y])yu(\w{0,2}\d)/$1ue$2/ # e.g. 全 chuen 屯門 Tuen
-    
-    - derive/([^y])yu(\w{0,2}\d)/$1u$2/ # e.g. 豬 Ju
-    
-    # 教院轉換成粵拼
-    #- derive/^z/dz/
-    #- derive/^c/ts/
-    #- derive/eoi$/oey/
-    #- derive/eon$/oen/
-    #- derive/eot$/oet/
-    #- derive/yu$/y/
-    #- derive/yun$/yn/
-    #- derive/yut$/yt/
-    
-    - abbrev/^([a-z]).+$/$1/      # 首字母簡拼
-    # - abbrev/^([a-z]).+([1-6])$/$1$2/      # 首字母聲調簡拼
-    # - abbrev/^([a-z]{2}).+([1-6])$/$1$2/   # 首2字母聲調簡拼
-    # - abbrev/^([a-z]{2}).+$/$1/   # 首2字母簡拼
-    
-    - derive/[123456]//           # 忽略聲調
+    - derive/ou/o/ # e.g. 好 ho
+    - derive/^([bpmdtnlh]|ng)?ou/$1u/ # e.g. 報 bu/boo
+    - derive/ei/i/ # e.g. 李 Li/Lee
+
+    - derive/^yu/yue/ # e.g. 元朗 Yuen
+    - derive/(?!^)yu/ue/ # e.g. 屯門 Tuen
+    - derive/ue(?=\d)/u/ # e.g. 豬 Ju
+
+    - derive/(?<![aeioy])u/oo/ # e.g. 美乎 Foo
+    - derive/(?<![aeou])i(?!ng|k)/ee/ # e.g. 以 yee
+
+    - derive/(?<=[aeou])i/y/ # e.g. 財 choy
+    - derive/(?<=[aeio])u/w/ # e.g. 老 low
+
+    - derive/eo/u/
+    - derive/oe/eo/
+    - derive/eo/oe/
+
+    - abbrev/^([a-z]).+$/$1/ # 首字母簡拼
+    - abbrev/^([gk]w|ng).+$/$1/ # 首2字母簡拼
+
+    - derive/((?!^)([mptk]|ng?))?\d/h$&/ # 個 goh 野 yeh
+
+    # 教院聲母
+    - derive/zh/dz/ # e.g. 知 dzi
+    - derive/ch/ts/ # e.g. 荃灣 Tsuen
+
+    - derive/\d// # 忽略聲調
 
 translator:
   dictionary: jyut6ping3
   spelling_hints: 256
   always_show_comments: true
   prism: yale
-  # TODO Show JyutPing in Yale mode to encourage users to learn JyutPing
-  comment_format:
-    - xform/oeng/eung/
-    - xform/oek/euk/
-    - xform/eoi/eui/
-    - xform/eon/eun/
-    - xform/eot/eut/
-    - xform/jyu/yu/
-    - xform/oe/eu/
-    - xform/aa(\>|\d)/a$1/
-    - xform/j/y/
-    - xform/z/j/
-    - xform/c/ch/
+  preedit_format:
+    - xform/j|dz/z/
+    - xform/ts/c/
+    - xform/ee|(?<=[aeou])y/i/
+    - xform/oo|(?<=[aeio])w/u/
+    - xform/(?!^)(?<![ '])h|q(?=[aeiou])//
+    - xform/[uo](?=[mp])/a/
+    - xform/r|(?<!a)a(?=$|[ '\d])/aa/
+    - xform/(^|[ '])(y(?=$|[aeio '\d]|ue?(ng|k)|ui)|(?=y))/$1j/
+    - xform/y?ue|(?<=[zcsj])u(?=$|[ '\d])|y(?!u)/yu/
+    - xform/((?<=[dtnlzcsjh])u|oe|eu)(?!$|ng|[k '\d])/eo/
+    - xform/(eo|eu)(?=$|ng|[k '\d])/oe/
+    - xform/(^|[ '])eot/$1oet/
+    - xform/(^|[bpmfdtnlgkh '])i(?=$|[ '\d])/$1ei/
+    - xform/(^|[bpmdtnlh ']|ng)u(?=$|[ '\d])/$1ou/
+
+  # Jyutping to Yale
+  # comment_format:
+    # - xform/aa(?=\d)/a/
+    # - xform/oe|eo/eu/
+    # - xform/jyu/yu/
+    # - xform/j/y/
+    # - xform/z/j/
+    # - xform/c/ch/
 
 variants_hk:
   option_name: variants_hk

--- a/CantoboardFramework/Data/Rime/yale.schema.yaml
+++ b/CantoboardFramework/Data/Rime/yale.schema.yaml
@@ -79,8 +79,10 @@ speller:
     - xform/jy?/y/
     - derive/yu(?!ng|k)/y/
     - erase/^y\d$/
-    - derive/aa/r/
     - derive/oe|eo/eu/
+    - derive/aa/r/
+    - derive/eu/v/
+    - derive/ng/x/
     - derive/aa(?=\d)/a/
     - derive/z/j/
     - derive/c/ch/
@@ -131,6 +133,7 @@ translator:
   preedit_format:
     - xform/j|dz/z/
     - xform/ts/c/
+    - xform/x/ng/
     - xform/ee|(?<=[aeou])y/i/
     - xform/oo|(?<=[aeio])w/u/
     - xform/(?!^)(?<![ '])h|q(?=[aeiou])//
@@ -138,9 +141,9 @@ translator:
     - xform/r|(?<!a)a(?=$|[ '\d])/aa/
     - xform/(^|[ '])(y(?=$|[aeio '\d]|ue?(ng|k)|ui)|(?=y))/$1j/
     - xform/y?ue|(?<=[zcsj])u(?=$|[ '\d])|y(?!u)/yu/
-    - xform/((?<=[dtnlzcsjh])u|oe|eu)(?!$|ng|[k '\d])/eo/
-    - xform/(eo|eu)(?=$|ng|[k '\d])/oe/
-    - xform/(^|[ '])eot/$1oet/
+    - xform/((?<=[dtnlzcsjh])u|oe|eu|v)(?!$|ng|[k '\d])/eo/
+    - xform/(eo|eu|v)(?=$|ng|[k '\d])/oe/
+    - xform/(^|[ ']|ng)eot/$1oet/
     - xform/(^|[bpmfdtnlgkh '])i(?=$|[ '\d])/$1ei/
     - xform/(^|[bpmdtnlh ']|ng)u(?=$|[ '\d])/$1ou/
 


### PR DESCRIPTION
The ordering of the rules are tested carefully.

Additional changes are discouraged – any removal of rules or change of characters or ordering may break the schema.

(`z → dz`, `c → ts` are moved to the bottom.)