### PR TITLE
Unify Chinese and English keyboard keys

### DIFF
--- a/CantoboardFramework/Keyboard/View/KeyCap.swift
+++ b/CantoboardFramework/Keyboard/View/KeyCap.swift
@@ -327,7 +327,7 @@ indirect enum KeyCap: Equatable, ExpressibleByStringLiteral {
         case "9": return ["九", "9", "玖", "９", "⑨", "⑼", "⒐", "❾", "㊈", "㈨"]
         case "0": return ["0", "０", "零", "十", "拾", "⓪", "°"]
         // 123 2nd row
-        case "-": return ["-", "－", "–", "—"]
+        case "-": return ["-", "－", "–", "—", "•"]
         case "/": return ["/", "／", "\\"]
         case ":": return [":", "："]
         case ";": return [";", "；"]
@@ -367,7 +367,7 @@ indirect enum KeyCap: Equatable, ExpressibleByStringLiteral {
         case "«": return ["«", "《"]
         case "»": return ["»", "》"]
         case "&": return ["＆", "&", "§"]
-        case "·": return ["·", "．", "•", "°"]
+        case "•": return ["•", "·", "．", "°"]
         // #+= 4th row
         case "…": return ["…", "⋯"]
         // 123 2nd row full width
@@ -397,6 +397,7 @@ indirect enum KeyCap: Equatable, ExpressibleByStringLiteral {
         case "〉": return ["〉", ">", "＞"]
         case "《": return ["《", "«"]
         case "》": return ["》", "»"]
+        case "·": return ["·", "．", "•", "°"]
         // #+= 4th row full width
         case "⋯": return ["…", "⋯"]
         case .currency:

--- a/CantoboardFramework/Keyboard/View/KeyCap.swift
+++ b/CantoboardFramework/Keyboard/View/KeyCap.swift
@@ -257,7 +257,7 @@ indirect enum KeyCap: Equatable, ExpressibleByStringLiteral {
             case "s": return "丨"
             case "p": return "丿"
             case "n": return "丶"
-            case "z": return "乙"
+            case "z": return "乛"
             default: return nil
             }
         case .exportFile(let namePrefix, _): return namePrefix.capitalized
@@ -327,20 +327,20 @@ indirect enum KeyCap: Equatable, ExpressibleByStringLiteral {
         case "9": return ["九", "9", "玖", "９", "⑨", "⑼", "⒐", "❾", "㊈", "㈨"]
         case "0": return ["0", "０", "零", "十", "拾", "⓪", "°"]
         // 123 2nd row
-        case "-": return ["-", "－", "–", "—", "•"]
+        case "-": return ["-", "－", "–", "—"]
         case "/": return ["/", "／", "\\"]
         case ":": return [":", "："]
         case ";": return [";", "；"]
         case "(": return ["(", "（"]
         case ")": return [")", "）"]
         case .doubleQuote: return ["\"", "＂", "”", "“", "„", "»", "«"]
-        case "「": return ["「", "『", "“", "‘"]
-        case "」": return ["」", "』", "”", "’"]
+        case "｢": return ["｢", "「", "『", "“", "‘"]
+        case "｣": return ["｣", "」", "』", "”", "’"]
         // 123 3rd row
-        case ".": return [".", "。", "．", "…", "⋯", "⋯⋯", "》"]
-        case ",": return [",", "，", "《"]
+        case ".": return [".", "。", "．", "…", "⋯", "⋯⋯"]
+        case ",": return [",", "，"]
         case "､": return ["､", "、"]
-        case "&": return ["＆", "&", "§"]
+        case "^_^": return ["^_^", "^‿^", ">_<"]
         case "?": return ["?", "？", "¿"]
         case "!": return ["!", "！", "¡"]
         case .singleQuote: return ["'", "＇", "’", "‘", "`", "｀"]
@@ -366,51 +366,30 @@ indirect enum KeyCap: Equatable, ExpressibleByStringLiteral {
         case ">": return [">", "〉", "＞"]
         case "«": return ["«", "《"]
         case "»": return ["»", "》"]
-        case "•": return ["•", "·", "．", "°"]
-        // #+= 3rd row
+        case "&": return ["＆", "&", "§"]
+        case "·": return ["·", "．", "•", "°"]
+        // #+= 4th row
         case "…": return ["…", "⋯"]
-        // 123 1st row full width
-        case "１": return ["１", "一", "壹", "1", "①", "⑴", "⒈", "❶", "㊀", "㈠"]
-        case "２": return ["貳", "２", "二", "2", "②", "⑵", "⒉", "❷", "㊁", "㈡"]
-        case "３": return ["③", "叁", "３", "三", "3", "⑶", "⒊", "❸", "㊂", "㈢"]
-        case "４": return ["⒋", "④", "肆", "４", "四", "4", "⑷", "❹", "㊃", "㈣"]
-        case "５": return ["㊄", "⒌", "⑤", "伍", "５", "五", "5", "⑸", "❺", "㈤"]
-        case "６": return ["❻", "⑹", "6", "六", "６", "陸", "⑥", "⒍", "㊅", "㈥"]
-        case "７": return ["⑺", "7", "七", "７", "柒", "⑦", "⒎", "❼", "㊆", "㈦"]
-        case "８": return ["8", "八", "８", "捌", "⑧", "⑻", "⒏", "❽", "㊇", "㈧"]
-        case "９": return ["九", "９", "玖", "9", "⑨", "⑼", "⒐", "❾", "㊈", "㈨"]
-        case "０": return ["０", "0", "零", "十", "拾", "⓪", "°"]
         // 123 2nd row full width
-        case "－": return ["－", "-", "–", "—", "•"]
         case "／": return ["／", "/", "\\"]
         case "：": return ["：", ":"]
         case "；": return ["；", ";"]
         case "（": return ["（", "("]
         case "）": return ["）", ")"]
-        case "＂": return ["＂", "\"", "”", "“", "»", "«"]
+        case "「": return ["「", "『", "“", "‘", "｢", "｣"]
+        case "」": return ["」", "』", "”", "’"]
         // 123 3rd row full width
         case "。": return ["。", ".", "．", "…", "⋯", "⋯⋯"]
         case "，": return ["，", ", "]
-        case "＆": return ["&", "＆", "§"]
         case "、": return ["､", "、"]
         case "？": return ["？", "?", "¿"]
         case "！": return ["！", "!", "¡"]
-        case "＇": return ["＇", "'", "’", "‘", "`", "｀"]
-        // 123 4rd row full width
-        case "＠": return ["＠", "@"]
         // #+= 1st row full width
         case "［": return ["［", "[", "【", "〔"]
         case "］": return ["］", "]", "】", "〕"]
         case "｛": return ["｛", "{"]
         case "｝": return ["｝", "}"]
-        case "＃": return ["＃", "#"]
-        case "％": return ["％", "%", "‰"]
-        case "＾": return ["＾", "^"]
-        case "＊": return ["＊", "*"]
-        case "＋": return ["＋", "+"]
-        case "＝": return ["＝", "=", "≠", "≈"]
         // #+= 2nd row full width
-        case "＿": return ["＿", "_"]
         case "＼": return ["＼", "\\"]
         case "｜": return ["｜", "|"]
         case "～": return ["～", "~"]
@@ -418,8 +397,7 @@ indirect enum KeyCap: Equatable, ExpressibleByStringLiteral {
         case "〉": return ["〉", ">", "＞"]
         case "《": return ["《", "«"]
         case "》": return ["》", "»"]
-        case "·": return ["·", "．", "•", "°"]
-        // #+= 3rd row full width
+        // #+= 4th row full width
         case "⋯": return ["…", "⋯"]
         case .currency:
             var currencyLists: [KeyCap] =  ["¢", "$", "€", "£", "¥", "₩", "₽", "＄"]
@@ -437,20 +415,6 @@ indirect enum KeyCap: Equatable, ExpressibleByStringLiteral {
         switch self {
         case .character(".", "/", _): return nil // Contextual sym key in url mode
         default: return self.buttonText
-        }
-    }
-    
-    var keyCapCharacter: String? {
-        switch self {
-        case .character(let c, _, _), .cangjie(let c, _): return c.lowercased()
-        default: return nil
-        }
-    }
-    
-    var isCharacter: Bool {
-        switch self {
-        case .character, .cangjie: return true
-        default: return false
         }
     }
     

--- a/CantoboardFramework/Keyboard/View/Keyboard/KeyboardViewLayout.swift
+++ b/CantoboardFramework/Keyboard/View/Keyboard/KeyboardViewLayout.swift
@@ -25,15 +25,7 @@ protocol KeyboardViewLayout {
     static func getContextualKeys(key: ContextualKey, keyboardState: KeyboardState) -> KeyCap?
     static func getKeyHeight(atRow: Int, layoutConstants: LayoutConstants) -> CGFloat
     static func getSwipeDownKeyCap(keyCap: KeyCap, keyboardState: KeyboardState) -> KeyCap?
-}
-
-extension KeyboardViewLayout {
-    static func isSwipeDownKeyShiftMorphing(keyCap: KeyCap) -> Bool {
-        switch keyCap {
-        case .character(let c, _, _), .cangjie(let c, _): return !(c.first?.isLetter ?? false)
-        default: return true
-        }
-    }
+    static func isSwipeDownKeyShiftMorphing(keyCap: KeyCap) -> Bool
 }
 
 class CommonContextualKeys {
@@ -57,8 +49,17 @@ class CommonContextualKeys {
 }
 
 class CommonSwipeDownKeys {
-    static func getSwipeDownKeyCapForPadShortOrFull4Rows(keyCap: KeyCap) -> KeyCap? {
-        switch keyCap.keyCapCharacter {
+    static func getSwipeDownKeyCapForPadShortOrFull4Rows(keyCap: KeyCap, keyboardState: KeyboardState) -> KeyCap? {
+        let isInChineseContextualMode = !keyboardState.keyboardContextualType.isEnglish
+        let keyCapCharacter: String?
+        switch keyCap {
+        case .character(let c, _, _), .cangjie(let c, _): keyCapCharacter = c.lowercased()
+        case .currency: keyCapCharacter = "$"
+        case .singleQuote: keyCapCharacter = "'"
+        case .doubleQuote: keyCapCharacter = "\""
+        default: keyCapCharacter = nil
+        }
+        switch keyCapCharacter {
         case "q": return "1"
         case "w": return "2"
         case "e": return "3"
@@ -71,27 +72,49 @@ class CommonSwipeDownKeys {
         case "p": return "0"
         case "a": return "@"
         case "s": return "#"
-        case "d": return "$"
-        case "f": return "&"
-        case "g": return "*"
-        case "h": return "("
-        case "j": return ")"
-        case "k": return .singleQuote
-        case "l": return .doubleQuote
+        case "d": return .currency
+        case "f": return isInChineseContextualMode ? "／" : "/"
+        case "g": return isInChineseContextualMode ? "（" : "("
+        case "h": return isInChineseContextualMode ? "）" : ")"
+        case "j": return isInChineseContextualMode ? "「" : "｢"
+        case "k": return isInChineseContextualMode ? "」" : "｣"
+        case "l": return .singleQuote
         case "z": return "%"
         case "x": return "-"
-        case "c": return "+"
-        case "v": return "="
-        case "b": return "/"
-        case "n": return ";"
-        case "m": return ":"
+        case "c": return isInChineseContextualMode ? "~" : "～"
+        case "v": return isInChineseContextualMode ? "⋯" : "…"
+        case "b": return isInChineseContextualMode ? "、" : "､"
+        case "n": return isInChineseContextualMode ? "；" : ";"
+        case "m": return isInChineseContextualMode ? "：" : ":"
         case ",": return "!"
         case ".": return "?"
         case "，": return "！"
         case "。": return "？"
-        default: ()
+        case "@": return "^"
+        case "#": return "_"
+        case "$": return isInChineseContextualMode ? "｜" : "|"
+        case "/": return "\\"
+        case "／": return "＼"
+        case "(": return "["
+        case ")": return "]"
+        case "（": return "［"
+        case "）": return "］"
+        case "｢": return "{"
+        case "｣": return "}"
+        case "「": return "｛"
+        case "」": return "｝"
+        case "'": return .doubleQuote
+        case "%": return "*"
+        case "-", "–": return "&"
+        case "~", "～": return "+"
+        case "…", "⋯": return "="
+        case "､", "、": return "·"
+        case ";": return "<"
+        case "；": return "《"
+        case ":": return ">"
+        case "：": return "》"
+        default: return nil
         }
-        return nil
     }
 }
 

--- a/CantoboardFramework/Keyboard/View/Keyboard/PadFull4RowsKeyboardViewLayout.swift
+++ b/CantoboardFramework/Keyboard/View/Keyboard/PadFull4RowsKeyboardViewLayout.swift
@@ -37,7 +37,7 @@ class PadFull4RowsKeyboardViewLayout : KeyboardViewLayout {
     static let symbolsHalf: [[[KeyCap]]] = [
         [["\t"], ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"], [.backspace]],
         [[.placeholder(.toggleInputMode(.english, nil))], ["^", "_", "|", "\\", "[", "]", "{", "}", .doubleQuote], [.returnKey(.default)]],
-        [[.keyboardType(.numeric)], ["*", "&", "+", "=", "·", "<", ">", "!", "?"], [.keyboardType(.numeric)]],
+        [[.keyboardType(.numeric)], ["*", "&", "+", "=", "•", "<", ">", "!", "?"], [.keyboardType(.numeric)]],
         [[.nextKeyboard, .keyboardType(.alphabetic(.lowercased))], [.space(.space)], [.keyboardType(.alphabetic(.lowercased)), .dismissKeyboard]]
     ]
     

--- a/CantoboardFramework/Keyboard/View/Keyboard/PadFull4RowsKeyboardViewLayout.swift
+++ b/CantoboardFramework/Keyboard/View/Keyboard/PadFull4RowsKeyboardViewLayout.swift
@@ -22,29 +22,29 @@ class PadFull4RowsKeyboardViewLayout : KeyboardViewLayout {
     
     static let numbersHalf: [[[KeyCap]]] = [
         [["\t"], ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"], [.backspace]],
-        [[.placeholder(.toggleInputMode(.english, nil))], ["@", "#", "$", "&", "*", "(", ")", .singleQuote, .doubleQuote], [.returnKey(.default)]],
-        [[.keyboardType(.symbolic)], ["%", "-", "+", "=", "/", ";", ":", ",", "."], [.keyboardType(.symbolic)]],
+        [[.placeholder(.toggleInputMode(.english, nil))], ["@", "#", .currency, "/", "(", ")", "｢", "｣", .singleQuote], [.returnKey(.default)]],
+        [[.keyboardType(.symbolic)], ["%", "-", "~", "…", "､", ";", ":", ",", "."], [.keyboardType(.symbolic)]],
         [[.nextKeyboard, .keyboardType(.alphabetic(.lowercased))], [.space(.space)], [.keyboardType(.alphabetic(.lowercased)), .dismissKeyboard]]
     ]
     
     static let numbersFull: [[[KeyCap]]] = [
         [["\t"], ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"], [.backspace]],
-        [[.placeholder(.toggleInputMode(.english, nil))], ["@", "#", "$", "/", "(", ")", "「", "」", .singleQuote], [.returnKey(.default)]],
-        [[.keyboardType(.symbolic)], ["%", "-", "～", "⋯", "、", "；", "：", "，", "。"], [.keyboardType(.symbolic)]],
+        [[.placeholder(.toggleInputMode(.english, nil))], ["@", "#", .currency, "／", "（", "）", "「", "」", .singleQuote], [.returnKey(.default)]],
+        [[.keyboardType(.symbolic)], ["%", "–", "～", "⋯", "、", "；", "：", "，", "。"], [.keyboardType(.symbolic)]],
         [[.nextKeyboard, .keyboardType(.alphabetic(.lowercased))], [.space(.space)], [.keyboardType(.alphabetic(.lowercased)), .dismissKeyboard]]
     ]
     
     static let symbolsHalf: [[[KeyCap]]] = [
         [["\t"], ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"], [.backspace]],
-        [[.placeholder(.toggleInputMode(.english, nil))], ["€", "£", "¥", "_", "^", "[", "]", "{", "}"], [.returnKey(.default)]],
-        [[.keyboardType(.numeric)], ["§", "|", "~", "…", "\\", "<", ">", "!", "?"], [.keyboardType(.numeric)]],
+        [[.placeholder(.toggleInputMode(.english, nil))], ["^", "_", "|", "\\", "[", "]", "{", "}", .doubleQuote], [.returnKey(.default)]],
+        [[.keyboardType(.numeric)], ["*", "&", "+", "=", "·", "<", ">", "!", "?"], [.keyboardType(.numeric)]],
         [[.nextKeyboard, .keyboardType(.alphabetic(.lowercased))], [.space(.space)], [.keyboardType(.alphabetic(.lowercased)), .dismissKeyboard]]
     ]
     
     static let symbolsFull: [[[KeyCap]]] = [
-        [["\t"], ["^", "_", "|", "\\", "<", ">", "{", "}", ",", "."], [.backspace]],
-        [[.placeholder(.toggleInputMode(.english, nil))], ["&", "¥", "€", "*", "【", "】", "『", "』", .doubleQuote], [.returnKey(.default)]],
-        [[.keyboardType(.numeric)], ["^_^", "—", "+", "=", "·", "《", "》", "！", "？"], [.keyboardType(.numeric)]],
+        [["\t"], ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"], [.backspace]],
+        [[.placeholder(.toggleInputMode(.english, nil))], ["^", "_", "｜", "＼", "［", "］", "｛", "｝", .doubleQuote], [.returnKey(.default)]],
+        [[.keyboardType(.numeric)], ["*", "&", "+", "=", "·", "《", "》", "！", "？"], [.keyboardType(.numeric)]],
         [[.nextKeyboard, .keyboardType(.alphabetic(.lowercased))], [.space(.space)], [.keyboardType(.alphabetic(.lowercased)), .dismissKeyboard]]
     ]
     
@@ -131,6 +131,10 @@ class PadFull4RowsKeyboardViewLayout : KeyboardViewLayout {
     }
     
     static func getSwipeDownKeyCap(keyCap: KeyCap, keyboardState: KeyboardState) -> KeyCap? {
-        return CommonSwipeDownKeys.getSwipeDownKeyCapForPadShortOrFull4Rows(keyCap: keyCap)
+        return CommonSwipeDownKeys.getSwipeDownKeyCapForPadShortOrFull4Rows(keyCap: keyCap, keyboardState: keyboardState)
+    }
+    
+    static func isSwipeDownKeyShiftMorphing(keyCap: KeyCap) -> Bool {
+        return keyCap == "," || keyCap == "." || keyCap == "，" || keyCap == "。"
     }
 }

--- a/CantoboardFramework/Keyboard/View/Keyboard/PadFull5RowsKeyboardViewLayout.swift
+++ b/CantoboardFramework/Keyboard/View/Keyboard/PadFull5RowsKeyboardViewLayout.swift
@@ -14,7 +14,7 @@ class PadFull5RowsKeyboardViewLayout : KeyboardViewLayout {
     static let numOfRows = 5
     
     static let letters: [[[KeyCap]]] = [
-        [[], [.contextual("`"), "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "="], [.backspace]],
+        [[], [.contextual("•"), "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "="], [.backspace]],
         [["\t"], ["q", "w", "e", "r", "t", "y", "u", "i", "o", "p", .contextual("["), .contextual("]"), .contextual("\\")], []],
         [[.toggleInputMode(.english, nil)], ["a", "s", "d", "f", "g", "h", "j", "k", "l", .contextual(";"), .singleQuote], [.returnKey(.default)]],
         [[.shift(.lowercased)], ["z", "x", "c", "v", "b", "n", "m", .contextual(","), .contextual("."), .contextual("/")], [.shift(.lowercased)]],
@@ -133,7 +133,7 @@ class PadFull5RowsKeyboardViewLayout : KeyboardViewLayout {
             case "\\": return "、"
             case ";": return "；"
             case "/": return "／"
-            case "`": return "·"
+            case "•": return "·"
             default: ()
             }
         } else if case .character(let c) = key, c != ".com" {
@@ -150,7 +150,7 @@ class PadFull5RowsKeyboardViewLayout : KeyboardViewLayout {
         let isInChineseContextualMode = !keyboardState.keyboardContextualType.isEnglish
         if case .alphabetic = keyboardState.keyboardType {
             switch keyCap {
-            case "`": return "~"
+            case "•": return "~"
             case "·": return "～"
             case "1": return isInChineseContextualMode ? "！" : "!"
             case "2": return "@"

--- a/CantoboardFramework/Keyboard/View/Keyboard/PadFull5RowsKeyboardViewLayout.swift
+++ b/CantoboardFramework/Keyboard/View/Keyboard/PadFull5RowsKeyboardViewLayout.swift
@@ -24,16 +24,16 @@ class PadFull5RowsKeyboardViewLayout : KeyboardViewLayout {
     static let numbersHalf: [[[KeyCap]]] = [
         [[], ["`", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "<", ">"], [.backspace]],
         [["\t"], ["[", "]", "{", "}", "#", "%", "^", "*", "+", "=", "\\", "|", "_"], []],
-        [[.placeholder(.toggleInputMode(.english, nil))], ["-", "/", ":", ";", "(", ")", .currency, "&", "@", .singleQuote, "¥"], [.returnKey(.default)]],
-        [[.placeholder(.shift(.lowercased))], ["^_^", "…", ".", ",", "、", "?", "!", "~", "“", "”", "€", "£"], []],
+        [[.placeholder(.toggleInputMode(.english, nil))], ["-", "/", ":", ";", "(", ")", .currency, "&", "@", .singleQuote, .doubleQuote], [.returnKey(.default)]],
+        [[.placeholder(.shift(.lowercased))], ["^_^", "…", ".", ",", "､", "?", "!", "~", "｢", "｣"], [.placeholder(.shift(.lowercased))]],
         [[.nextKeyboard, .keyboardType(.alphabetic(.lowercased))], [.space(.space)], [.keyboardType(.alphabetic(.lowercased)), .dismissKeyboard]]
     ]
     
     static let numbersFull: [[[KeyCap]]] = [
         [[], ["`", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "<", ">"], [.backspace]],
-        [["\t"], ["［", "］", "｛", "｝", "＃", "％", "＾", "＊", "＋", "＝", "＼", "｜", "＿"], []],
-        [[.placeholder(.toggleInputMode(.english, nil))], ["－", "／", "：", "；", "（", "）", .currency, "＆", "＠", .singleQuote, "¥"], [.returnKey(.default)]],
-        [[.placeholder(.shift(.lowercased))], ["^_^", "⋯", "。", "，", "、", "？", "！", "～", "＂", "＇", "「", "」"], []],
+        [["\t"], ["［", "］", "｛", "｝", "#", "%", "^", "*", "+", "=", "＼", "｜", "_"], []],
+        [[.placeholder(.toggleInputMode(.english, nil))], ["–", "／", "：", "；", "（", "）", .currency, "&", "@", .singleQuote, .doubleQuote], [.returnKey(.default)]],
+        [[.placeholder(.shift(.lowercased))], ["^_^", "⋯", "。", "，", "、", "？", "！", "～", "「", "」"], [.placeholder(.shift(.lowercased))]],
         [[.nextKeyboard, .keyboardType(.alphabetic(.lowercased))], [.space(.space)], [.keyboardType(.alphabetic(.lowercased)), .dismissKeyboard]]
     ]
     
@@ -108,11 +108,7 @@ class PadFull5RowsKeyboardViewLayout : KeyboardViewLayout {
                  .keyboardType where index <= 2:
                 width = (padFull5RowsLayoutConstants.smallSystemKeyWidth * 3 + 2 * layoutConstants.buttonGapX - layoutConstants.buttonGapX) / 2
             case .keyboardType, .dismissKeyboard:
-                if keyRowView.rowId == 4 && keys.contains(where: { $0.keyCap.isCharacter }) {
-                    width = padFull5RowsLayoutConstants.smallSystemKeyWidth
-                } else {
-                    width = padFull5RowsLayoutConstants.largeSystemKeyWidth
-                }
+                width = padFull5RowsLayoutConstants.largeSystemKeyWidth
             case .character, .cangjie, .currency, .singleQuote, .doubleQuote: width = inputKeyWidth
             default:
                 width = 0
@@ -153,7 +149,7 @@ class PadFull5RowsKeyboardViewLayout : KeyboardViewLayout {
     static func getSwipeDownKeyCap(keyCap: KeyCap, keyboardState: KeyboardState) -> KeyCap? {
         let isInChineseContextualMode = !keyboardState.keyboardContextualType.isEnglish
         if case .alphabetic = keyboardState.keyboardType {
-            switch keyCap.keyCapCharacter {
+            switch keyCap {
             case "`": return "~"
             case "·": return "～"
             case "1": return isInChineseContextualMode ? "！" : "!"
@@ -172,20 +168,24 @@ class PadFull5RowsKeyboardViewLayout : KeyboardViewLayout {
             case "]": return "}"
             case "\\": return "|"
             case ";": return ":"
-            case "'": return .doubleQuote
+            case .singleQuote: return .doubleQuote
             case ",": return "<"
             case ".": return ">"
             case "/": return "?"
             case "／": return "？"
-            case "，": return "《 "
-            case "。": return " 》"
-            case "「": return "『 "
-            case "」": return " 』"
+            case "，": return "《"
+            case "。": return "》"
+            case "「": return "『"
+            case "」": return "』"
             case "、": return "｜"
             case "；": return "："
             default: ()
             }
         }
         return nil
+    }
+    
+    static func isSwipeDownKeyShiftMorphing(keyCap: KeyCap) -> Bool {
+        return true
     }
 }

--- a/CantoboardFramework/Keyboard/View/Keyboard/PadShortKeyboardViewLayout.swift
+++ b/CantoboardFramework/Keyboard/View/Keyboard/PadShortKeyboardViewLayout.swift
@@ -20,29 +20,29 @@ class PadShortKeyboardViewLayout : KeyboardViewLayout {
     
     static let numbersHalf: [[[KeyCap]]] = [
         [[], ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"], [.backspace]],
-        [[], ["@", "#", "$", "&", "*", "(", ")", .singleQuote, .doubleQuote], [.returnKey(.default)]],
-        [[.keyboardType(.symbolic)], ["%", "-", "+", "=", "/", ";", ":", ",", "."], [.keyboardType(.symbolic)]],
+        [[], ["@", "#", .currency, "/", "(", ")", "｢", "｣", .singleQuote], [.returnKey(.default)]],
+        [[.keyboardType(.symbolic)], ["%", "-", "~", "…", "､", ";", ":", ",", "."], [.keyboardType(.symbolic)]],
         [[.keyboardType(.alphabetic(.lowercased)), .nextKeyboard], [.space(.space)], [.keyboardType(.alphabetic(.lowercased)), .dismissKeyboard]]
     ]
     
     static let numbersFull: [[[KeyCap]]] = [
         [[], ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"], [.backspace]],
-        [[], ["@", "#", "$", "/", "(", ")", "「", "」", .singleQuote], [.returnKey(.default)]],
-        [[.keyboardType(.symbolic)], ["%", "-", "～", "⋯", "、", "；", "：", "，", "。"], [.keyboardType(.symbolic)]],
+        [[], ["@", "#", .currency, "／", "（", "）", "「", "」", .singleQuote], [.returnKey(.default)]],
+        [[.keyboardType(.symbolic)], ["%", "–", "～", "⋯", "、", "；", "：", "，", "。"], [.keyboardType(.symbolic)]],
         [[.keyboardType(.alphabetic(.lowercased)), .nextKeyboard], [.space(.space)], [.keyboardType(.alphabetic(.lowercased)), .dismissKeyboard]]
     ]
     
     static let symbolsHalf: [[[KeyCap]]] = [
         [[], ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"], [.backspace]],
-        [[], ["€", "£", "¥", "_", "^", "[", "]", "{", "}"], [.returnKey(.default)]],
-        [[.keyboardType(.numeric)], ["§", "|", "~", "…", "\\", "<", ">", "!", "?"], [.keyboardType(.numeric)]],
+        [[], ["^", "_", "|", "\\", "[", "]", "{", "}", .doubleQuote], [.returnKey(.default)]],
+        [[.keyboardType(.numeric)], ["*", "&", "+", "=", "·", "<", ">", "!", "?"], [.keyboardType(.numeric)]],
         [[.keyboardType(.alphabetic(.lowercased)), .nextKeyboard], [.space(.space)], [.keyboardType(.alphabetic(.lowercased)), .dismissKeyboard]]
     ]
     
     static let symbolsFull: [[[KeyCap]]] = [
-        [[], ["^", "_", "|", "\\", "<", ">", "{", "}", ",", "."], [.backspace]],
-        [[], ["&", "¥", "€", "*", "【", "】", "『", "』", .doubleQuote], [.returnKey(.default)]],
-        [[.keyboardType(.numeric)], ["^_^", "—", "+", "=", "·", "《", "》", "！", "？"], [.keyboardType(.numeric)]],
+        [[], ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"], [.backspace]],
+        [[], ["^", "_", "｜", "＼", "［", "］", "｛", "｝", .doubleQuote], [.returnKey(.default)]],
+        [[.keyboardType(.numeric)], ["*", "&", "+", "=", "·", "《", "》", "！", "？"], [.keyboardType(.numeric)]],
         [[.keyboardType(.alphabetic(.lowercased)), .nextKeyboard], [.space(.space)], [.keyboardType(.alphabetic(.lowercased)), .dismissKeyboard]]
     ]
     
@@ -126,6 +126,10 @@ class PadShortKeyboardViewLayout : KeyboardViewLayout {
     }
     
     static func getSwipeDownKeyCap(keyCap: KeyCap, keyboardState: KeyboardState) -> KeyCap? {
-        return CommonSwipeDownKeys.getSwipeDownKeyCapForPadShortOrFull4Rows(keyCap: keyCap)
+        return CommonSwipeDownKeys.getSwipeDownKeyCapForPadShortOrFull4Rows(keyCap: keyCap, keyboardState: keyboardState)
+    }
+    
+    static func isSwipeDownKeyShiftMorphing(keyCap: KeyCap) -> Bool {
+        return keyCap == "," || keyCap == "." || keyCap == "，" || keyCap == "。"
     }
 }

--- a/CantoboardFramework/Keyboard/View/Keyboard/PadShortKeyboardViewLayout.swift
+++ b/CantoboardFramework/Keyboard/View/Keyboard/PadShortKeyboardViewLayout.swift
@@ -35,7 +35,7 @@ class PadShortKeyboardViewLayout : KeyboardViewLayout {
     static let symbolsHalf: [[[KeyCap]]] = [
         [[], ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"], [.backspace]],
         [[], ["^", "_", "|", "\\", "[", "]", "{", "}", .doubleQuote], [.returnKey(.default)]],
-        [[.keyboardType(.numeric)], ["*", "&", "+", "=", "·", "<", ">", "!", "?"], [.keyboardType(.numeric)]],
+        [[.keyboardType(.numeric)], ["*", "&", "+", "=", "•", "<", ">", "!", "?"], [.keyboardType(.numeric)]],
         [[.keyboardType(.alphabetic(.lowercased)), .nextKeyboard], [.space(.space)], [.keyboardType(.alphabetic(.lowercased)), .dismissKeyboard]]
     ]
     

--- a/CantoboardFramework/Keyboard/View/Keyboard/PhoneKeyboardViewLayout.swift
+++ b/CantoboardFramework/Keyboard/View/Keyboard/PhoneKeyboardViewLayout.swift
@@ -20,30 +20,30 @@ class PhoneKeyboardViewLayout : KeyboardViewLayout {
     
     static let numbersHalf: [[[KeyCap]]] = [
         [["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"]],
-        [["-", "/", ":", ";", "(", ")", .currency, .doubleQuote, "「", "」"]],
-        [[.keyboardType(.symbolic)], [".", ",", "、", "&", "?", "!", .singleQuote], [.backspace]],
+        [["-", "/", ":", ";", "(", ")", .currency, .doubleQuote, "｢", "｣"]],
+        [[.keyboardType(.symbolic)], [".", ",", "､", "^_^", "?", "!", .singleQuote], [.backspace]],
         [[.keyboardType(.alphabetic(.lowercased)), .nextKeyboard], [.space(.space)], ["@", .returnKey(.default)]]
     ]
     
     static let symbolsHalf: [[[KeyCap]]] = [
         [["[", "]", "{", "}", "#", "%", "^", "*", "+", "="]],
-        [["_", "—", "\\", "|", "~", "<", ">", "«", "»", "•"]],
-        [[.keyboardType(.numeric)], [".", ",", "、", "^_^", "?", "!", .singleQuote], [.backspace]],
-        [[.keyboardType(.alphabetic(.lowercased)), .nextKeyboard], [.space(.space)], [.returnKey(.default)]]
+        [["_", "\\", "|", "~", "<", ">", "«", "»", "&", "·"]],
+        [[.keyboardType(.numeric)], [".", ",", "､", "^_^", "?", "!", .singleQuote], [.backspace]],
+        [[.keyboardType(.alphabetic(.lowercased)), .nextKeyboard], [.space(.space)], ["…", .returnKey(.default)]]
     ]
     
     static let numbersFull: [[[KeyCap]]] = [
         [["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"]],
-        [["－", "／", "：", "；", "（", "）", .currency, "＂", "「", "」"]],
-        [[.keyboardType(.symbolic)], ["。", "，", "、", "＆", "？", "！", "＇"], [.backspace]],
-        [[.keyboardType(.alphabetic(.lowercased)), .nextKeyboard], [.space(.space)], ["＠", .returnKey(.default)]]
+        [["–", "／", "：", "；", "（", "）", .currency, .doubleQuote, "「", "」"]],
+        [[.keyboardType(.symbolic)], ["。", "，", "、", "^_^", "？", "！", .singleQuote], [.backspace]],
+        [[.keyboardType(.alphabetic(.lowercased)), .nextKeyboard], [.space(.space)], ["@", .returnKey(.default)]]
     ]
     
     static let symbolsFull: [[[KeyCap]]] = [
-        [["［", "］", "｛", "｝", "＃", "％", "＾", "＊", "＋", "＝"]],
-        [["＿", "—", "＼", "｜", "～", "〈", "〉", "《", "》", "•"]],
-        [[.keyboardType(.numeric)], ["。", "，", "、", "^_^", "？", "！", "＇"], [.backspace]],
-        [[.keyboardType(.alphabetic(.lowercased)), .nextKeyboard], [.space(.space)], [.returnKey(.default)]]
+        [["［", "］", "｛", "｝", "#", "%", "^", "*", "+", "="]],
+        [["_", "＼", "｜", "～", "〈", "〉", "《", "》", "&", "·"]],
+        [[.keyboardType(.numeric)], ["。", "，", "、", "^_^", "？", "！", .singleQuote], [.backspace]],
+        [[.keyboardType(.alphabetic(.lowercased)), .nextKeyboard], [.space(.space)], ["⋯", .returnKey(.default)]]
     ]
     
     static func layoutKeyViews(keyRowView: KeyRowView, leftKeys: [KeyView], middleKeys: [KeyView], rightKeys: [KeyView], layoutConstants: LayoutConstants) -> [CGRect] {

--- a/CantoboardFramework/Keyboard/View/Keyboard/PhoneKeyboardViewLayout.swift
+++ b/CantoboardFramework/Keyboard/View/Keyboard/PhoneKeyboardViewLayout.swift
@@ -27,7 +27,7 @@ class PhoneKeyboardViewLayout : KeyboardViewLayout {
     
     static let symbolsHalf: [[[KeyCap]]] = [
         [["[", "]", "{", "}", "#", "%", "^", "*", "+", "="]],
-        [["_", "\\", "|", "~", "<", ">", "«", "»", "&", "·"]],
+        [["_", "\\", "|", "~", "<", ">", "«", "»", "&", "•"]],
         [[.keyboardType(.numeric)], [".", ",", "､", "^_^", "?", "!", .singleQuote], [.backspace]],
         [[.keyboardType(.alphabetic(.lowercased)), .nextKeyboard], [.space(.space)], ["…", .returnKey(.default)]]
     ]


### PR DESCRIPTION
This PR aims to unify symbols on Chinese and English keyboard keys.
There are a few reasons to do so:
- We want to improve the iOS keyboard to reflect the actual usage but not just copying.
- We don't want to see symbol shifting away while toggling between halfwidth and fullwidth.

Notice that the current phone keyboard layout ([file](https://github.com/Cantoboard/Cantoboard/blob/b6d2cf4cfb725571ff61acf001a41ffdf6ff6084/CantoboardFramework/Keyboard/View/Keyboard/PhoneKeyboardViewLayout.swift#L21-L47)) already differs from the default iOS one.

A new rule of whether a halfwidth or fullwidth equivalent of a symbol should be used has been drawn up:
- Use `，`, `。`, `！`, `？`, `：`, `；` as the fullwidth equivalent of `,`, `.`, `!`, `?`, `:`, `;` respectively.
- Use `／`, `＼`, `｜`, `～`, `⋯` as the fullwidth equivalent of `/`, `\`, `|`, `~`, `…` respectively.
- Use `（`, `）`, `［`, `］`, `｛`, `｝`, `〈`, `〉`, `《`, `》` as the fullwidth equivalent of `(`, `)`, `[`, `]`, `{`, `}`, `<`, `>`, `«`, `»` respectively.
- The en dash `–` acts as the fullwidth equivalent of the hyphen `-`.
- Use `｢`, `｣`, `､` as the halfwidth equivalent of `「`, `」`, `、` respectively.
- For other symbols, only put their halfwidth or fullwidth equivalent as their children key caps as there are no special advantages on using them.

The reason not to including the single and double quotes is that I noticed a pair of opening and closing double quotes `“` `”` is commonly used in simplified Chinese texts and some font may display them with the width of a fullwidth character.