### PR TITLE
".com" buttons for all iPads

### DIFF
--- a/CantoboardFramework/Keyboard/InputController.swift
+++ b/CantoboardFramework/Keyboard/InputController.swift
@@ -802,10 +802,10 @@ class InputController: NSObject {
     private func refreshKeyboardContextualType() {
         guard let textDocumentProxy = textDocumentProxy else { return }
         
-        if textDocumentProxy.keyboardType == .some(.URL) || textDocumentProxy.keyboardType == .some(.webSearch) {
-            state.keyboardContextualType = .url
-        } else if inputEngine.composition?.text != nil {
+        if inputEngine.composition?.text != nil {
             state.keyboardContextualType = .rime
+        } else if textDocumentProxy.keyboardType == .some(.URL) || textDocumentProxy.keyboardType == .some(.webSearch) {
+            state.keyboardContextualType = .url
         } else {
             let symbolShape = Settings.cached.symbolShape
             if symbolShape == .smart {

--- a/CantoboardFramework/Keyboard/InputController.swift
+++ b/CantoboardFramework/Keyboard/InputController.swift
@@ -802,10 +802,10 @@ class InputController: NSObject {
     private func refreshKeyboardContextualType() {
         guard let textDocumentProxy = textDocumentProxy else { return }
         
-        if inputEngine.composition?.text != nil {
-            state.keyboardContextualType = .rime
-        } else if textDocumentProxy.keyboardType == .some(.URL) || textDocumentProxy.keyboardType == .some(.webSearch) {
+        if textDocumentProxy.keyboardType == .some(.URL) || textDocumentProxy.keyboardType == .some(.webSearch) {
             state.keyboardContextualType = .url
+        } else if inputEngine.composition?.text != nil {
+            state.keyboardContextualType = .rime
         } else {
             let symbolShape = Settings.cached.symbolShape
             if symbolShape == .smart {

--- a/CantoboardFramework/Keyboard/View/KeyCap.swift
+++ b/CantoboardFramework/Keyboard/View/KeyCap.swift
@@ -58,6 +58,7 @@ enum KeyCapType {
 
 enum ContextualKey: Equatable, ExpressibleByStringLiteral {
     case symbol
+    case url
     case character(String)
     
     public init(stringLiteral value: String) {

--- a/CantoboardFramework/Keyboard/View/Keyboard/KeyboardView.swift
+++ b/CantoboardFramework/Keyboard/View/Keyboard/KeyboardView.swift
@@ -331,10 +331,10 @@ class KeyboardView: UIView, BaseKeyboardView {
             return .character(keyChar, hint, childrenKeyCaps)
         case .shift: return .shift(shiftState)
         case .keyboardType where groupId == 2 && state.keyboardIdiom.isPad:
-            if state.keyboardContextualType == .rime {
-                return CommonContextualKeys.getContextualKeys(key: .symbol, keyboardState: state)
-            } else {
-                return keyCap
+            switch state.keyboardContextualType {
+            case .rime: return CommonContextualKeys.getContextualKeys(key: .symbol, keyboardState: state)
+            case .url: return CommonContextualKeys.getContextualKeys(key: .url, keyboardState: state)
+            default: return keyCap
             }
         case .contextual: fatalError("Contextual isn't being translated properly. \(keyCap) \(state)")
         default: return keyCap

--- a/CantoboardFramework/Keyboard/View/Keyboard/KeyboardViewLayout.swift
+++ b/CantoboardFramework/Keyboard/View/Keyboard/KeyboardViewLayout.swift
@@ -41,9 +41,9 @@ class CommonContextualKeys {
             }
         case ",": return keyboardState.keyboardContextualType.isEnglish ? "," : "，"
         case ".": return keyboardState.keyboardContextualType.isEnglish ? "." : "。"
-        case ".com" where keyboardState.keyboardContextualType == .url: // For iPad Pro 12.9"
+        case .url: // For iPads
             let domains = [".net", ".org", ".edu", ".com", String("." + SessionState.main.localDomain), ".hk", ".tw", ".mo", ".cn", ".uk", ".jp"].unique()
-            return .character(".com", nil, domains.map{  .character($0, nil, nil) })
+            return .character(".com", nil, domains.map{ .character($0, nil, nil) })
         default: return nil
         }
     }

--- a/CantoboardFramework/Keyboard/View/Keyboard/PadFull5RowsKeyboardViewLayout.swift
+++ b/CantoboardFramework/Keyboard/View/Keyboard/PadFull5RowsKeyboardViewLayout.swift
@@ -18,7 +18,7 @@ class PadFull5RowsKeyboardViewLayout : KeyboardViewLayout {
         [["\t"], ["q", "w", "e", "r", "t", "y", "u", "i", "o", "p", .contextual("["), .contextual("]"), .contextual("\\")], []],
         [[.toggleInputMode(.english, nil)], ["a", "s", "d", "f", "g", "h", "j", "k", "l", .contextual(";"), .singleQuote], [.returnKey(.default)]],
         [[.shift(.lowercased)], ["z", "x", "c", "v", "b", "n", "m", .contextual(","), .contextual("."), .contextual("/")], [.shift(.lowercased)]],
-        [[.nextKeyboard, .keyboardType(.numSymbolic)], [.space(.space)], [.contextual(".com"), .keyboardType(.numSymbolic), .dismissKeyboard]]
+        [[.nextKeyboard, .keyboardType(.numSymbolic)], [.space(.space)], [.keyboardType(.numSymbolic), .dismissKeyboard]]
     ]
     
     static let numbersHalf: [[[KeyCap]]] = [
@@ -107,7 +107,7 @@ class PadFull5RowsKeyboardViewLayout : KeyboardViewLayout {
             case .nextKeyboard,
                  .keyboardType where index <= 2:
                 width = (padFull5RowsLayoutConstants.smallSystemKeyWidth * 3 + 2 * layoutConstants.buttonGapX - layoutConstants.buttonGapX) / 2
-            case .keyboardType, .dismissKeyboard:
+            case .keyboardType, .dismissKeyboard, .character(".com", _, _):
                 width = padFull5RowsLayoutConstants.largeSystemKeyWidth
             case .character, .cangjie, .currency, .singleQuote, .doubleQuote: width = inputKeyWidth
             default:
@@ -136,7 +136,7 @@ class PadFull5RowsKeyboardViewLayout : KeyboardViewLayout {
             case "•": return "·"
             default: ()
             }
-        } else if case .character(let c) = key, c != ".com" {
+        } else if case .character(let c) = key {
             return KeyCap(String(c))
         }
         return CommonContextualKeys.getContextualKeys(key: key, keyboardState: keyboardState)


### PR DESCRIPTION
There *are* ".com" keys for all types of iPad, not only 12.9′.
This PR replaces the keyboard type switching key with the ".com" key in a search field.
The rime 分 key is also made visible even in search fields.