### PR TITLE
Schema Support: Rounded Velar Consonants Before u

### DIFF
--- a/CantoboardFramework/Data/Rime/jyut6ping3.schema.yaml
+++ b/CantoboardFramework/Data/Rime/jyut6ping3.schema.yaml
@@ -4,7 +4,7 @@
 schema:
   schema_id: jyut6ping3
   name: 粵語拼音
-  version: "2020.11.26"
+  version: "2022.06.07"
   author:
     - sgalal <sgalal.me@outlook.com>
     - LeiMaau <leimaau@qq.com>
@@ -83,7 +83,7 @@ speller:
     - derive/^jyu/ju/             # 容錯 jyu -> ju
     - derive/yu/y/                # 容錯 jyu -> jy
     - erase/y(ng|k)/              # y + ng/k 視作簡拼而非 jung/juk
-    - derive/eoi(?=\d)/oey/       # 容錯
+    - derive/(g|k)u(?!ng|k)/$1wu/ # 輔音圓唇
     - derive/eoi(?=\d)/eoy/       # 容錯
     - derive/aa/r/                # 韻母簡拼
     - derive/oe|eo/v/             # 韻母簡拼

--- a/CantoboardFramework/Data/Rime/jyut6ping3_10keys.schema.yaml
+++ b/CantoboardFramework/Data/Rime/jyut6ping3_10keys.schema.yaml
@@ -4,7 +4,7 @@
 schema:
   schema_id: jyut6ping3_10keys
   name: 九宮格粵語拼音
-  version: "2020.11.26"
+  version: "2022.06.07"
   author:
     - sgalal <sgalal.me@outlook.com>
     - LeiMaau <leimaau@qq.com>
@@ -82,7 +82,7 @@ speller:
     - derive/^jyu/ju/             # 容錯 jyu -> ju
     - derive/yu/y/                # 容錯 jyu -> jy
     - erase/y(ng|k)/              # y + ng/k 視作簡拼而非 jung/juk
-    - derive/eoi(?=\d)/oey/       # 容錯
+    - derive/(g|k)u(?!ng|k)/$1wu/ # 輔音圓唇
     - derive/eoi(?=\d)/eoy/       # 容錯
     - derive/eo/oe/               # 容錯 eo/oe 不分
     - derive/oe/eo/               # 容錯 eo/oe 不分

--- a/CantoboardFramework/Data/Rime/jyut6ping3vxq.schema.yaml
+++ b/CantoboardFramework/Data/Rime/jyut6ping3vxq.schema.yaml
@@ -4,7 +4,7 @@
 schema:
   schema_id: jyut6ping3vxq
   name: 粵語拼音vxq
-  version: "2020.11.26"
+  version: "2022.06.07"
   author:
     - sgalal <sgalal.me@outlook.com>
     - LeiMaau <leimaau@qq.com>
@@ -83,7 +83,7 @@ speller:
     - derive/^jyu/ju/             # 容錯 jyu -> ju
     - derive/yu/y/                # 容錯 jyu -> jy
     - erase/y(ng|k)/              # y + ng/k 視作簡拼而非 jung/juk
-    - derive/eoi(?=\d)/oey/       # 容錯
+    - derive/(g|k)u(?!ng|k)/$1wu/ # 輔音圓唇
     - derive/eoi(?=\d)/eoy/       # 容錯
     - derive/eo/oe/               # 容錯 eo/oe 不分
     - derive/oe/eo/               # 容錯 eo/oe 不分
@@ -109,12 +109,12 @@ translator:
   always_show_comments: true
   prism: jyut6ping3vxq
   preedit_format:
-    - xform/([aeioumngxptk])vv/${1}4/
-    - xform/([aeioumngxptk])xx/${1}5/
-    - xform/([aeioumngxptk])qq/${1}6/
-    - xform/([aeioumngxptk])v/${1}1/
-    - xform/([aeioumngxptk])x/${1}2/
-    - xform/([aeioumngxptk])q/${1}3/
+    - xform/([aeiouymngptk])vv/${1}4/
+    - xform/([aeiouymngptk])xx/${1}5/
+    - xform/([aeiouymngptk])qq/${1}6/
+    - xform/([aeiouymngptk])v/${1}1/
+    - xform/([aeiouymngptk])x/${1}2/
+    - xform/([aeiouymngptk])q/${1}3/
 
 variants_hk:
   option_name: variants_hk

--- a/CantoboardFramework/Data/Rime/yale.schema.yaml
+++ b/CantoboardFramework/Data/Rime/yale.schema.yaml
@@ -4,7 +4,7 @@
 schema:
   schema_id: yale
   name: 耶魯–劉錫祥混合拼音
-  version: "2021.08.22"
+  version: "2022.06.07"
   author:
     - sgalal <sgalal.me@outlook.com>
     - LeiMaau <leimaau@qq.com>
@@ -78,6 +78,7 @@ speller:
     - xform/jy?/y/
     - derive/yu(?!ng|k)/y/
     - erase/^y\d$/
+    - derive/(g|k)u(?!ng|k)/$1wu/
     - derive/oe|eo/eu/
     - derive/aa/r/
     - derive/eu/v/

--- a/CantoboardFramework/Data/Rime/yalevxq.schema.yaml
+++ b/CantoboardFramework/Data/Rime/yalevxq.schema.yaml
@@ -4,7 +4,7 @@
 schema:
   schema_id: yalevxq
   name: 耶魯–劉錫祥混合拼音vxq
-  version: "2021.08.22"
+  version: "2022.06.07"
   author:
     - sgalal <sgalal.me@outlook.com>
     - LeiMaau <leimaau@qq.com>
@@ -78,6 +78,7 @@ speller:
     - xform/jy?/y/
     - derive/yu(?!ng|k)/y/
     - erase/^y\d$/
+    - derive/(g|k)u(?!ng|k)/$1wu/
     - derive/oe|eo/eu/
     - derive/aa(?=\d)/a/
     - derive/z/j/
@@ -96,7 +97,7 @@ speller:
     - derive/(?<!a)a(?=m|p)/o/ # e.g. 紅磡 Hom
 
     - derive/ou/o/ # e.g. 好 ho
-    - derive/^([bpmdtxlh]|ng?)?ou/$1u/ # e.g. 盧 Lu/Loo
+    - derive/^([bpmdtlh]|ng?)?ou/$1u/ # e.g. 盧 Lu/Loo
     - derive/ei/i/ # e.g. 李 Li/Lee
 
     - derive/^yu/yue/ # e.g. 元朗 Yuen
@@ -113,8 +114,8 @@ speller:
     - derive/oe/eo/
     - derive/eo/oe/
 
-    - derive/(?!^)([mxptk]|ng?)?\d/h$&/ # 個 goh 野 yeh
-    - erase/^(hh(m|ng|x)|(m|ng|x)h)\d$/
+    - derive/(?!^)([mptk]|ng?)?\d/h$&/ # 個 goh 野 yeh
+    - erase/^(hh(m|ng)|(m|ng)h)\d$/
 
     # 教院聲母
     - derive/zh/dz/ # e.g. 知 dzi
@@ -136,12 +137,12 @@ translator:
   always_show_comments: true
   prism: yalevxq
   preedit_format:
-    - xform/([aeioumngxptk])vv/${1}4/
-    - xform/([aeioumngxptk])xx/${1}5/
-    - xform/([aeioumngxptk])qq/${1}6/
-    - xform/([aeioumngxptk])v/${1}1/
-    - xform/([aeioumngxptk])x/${1}2/
-    - xform/([aeioumngxptk])q/${1}3/
+    - xform/([aeiouymngptk])vv/${1}4/
+    - xform/([aeiouymngptk])xx/${1}5/
+    - xform/([aeiouymngptk])qq/${1}6/
+    - xform/([aeiouymngptk])v/${1}1/
+    - xform/([aeiouymngptk])x/${1}2/
+    - xform/([aeiouymngptk])q/${1}3/
 
 variants_hk:
   option_name: variants_hk


### PR DESCRIPTION
- See https://github.com/rime/rime-cantonese/issues/158 and https://github.com/rime/rime-cantonese/pull/160.
- Lines of `derive/eoi(?=\d)/oey/` in Jyutping schemas are abundant since it is covered by `derive/eoi(?=\d)/eoy/` and `derive/eo/oe/`, so I removed them.
- `x`-es in vxq schemas are also abundant since shortcut keys are not provided, so the related lines are modified.
- Fix an issue that tones after `y`-s don't change to numbers in the two vxq schemas