### PR TITLE
Schema Bug Fix

### DIFF
--- a/CantoboardFramework/Data/Rime/jyut6ping3.schema.yaml
+++ b/CantoboardFramework/Data/Rime/jyut6ping3.schema.yaml
@@ -81,8 +81,7 @@ speller:
     - derive/^(?=[aeiou])/q/      # 增加 q 表示喉塞
     - derive/^jy?([aeiou])/y$1/   # 容錯 je -> ye, jyu -> yu
     - derive/^jyu/ju/             # 容錯 jyu -> ju
-    - derive/yu/y/                # 容錯 jyu -> jy
-    - erase/y(ng|k)/              # y + ng/k 視作簡拼而非 jung/juk
+    - derive/yu(?!ng|k)/y/        # 容錯 yu -> y
     - derive/(g|k)u(?!ng|k)/$1wu/ # 輔音圓唇
     - derive/eoi(?=\d)/eoy/       # 容錯
     - derive/aa/r/                # 韻母簡拼

--- a/CantoboardFramework/Data/Rime/jyut6ping3_10keys.schema.yaml
+++ b/CantoboardFramework/Data/Rime/jyut6ping3_10keys.schema.yaml
@@ -79,9 +79,9 @@ speller:
     # 取消下行註釋，支援獨立鼻音韻 ng 併入 m，如「吳」讀若「唔」
     #- derive/^ng(?=\d)/m/
 
+    - derive/^jy?([aeiou])/y$1/   # 容錯 je -> ye, jyu -> yu
     - derive/^jyu/ju/             # 容錯 jyu -> ju
-    - derive/yu/y/                # 容錯 jyu -> jy
-    - erase/y(ng|k)/              # y + ng/k 視作簡拼而非 jung/juk
+    - derive/yu(?!ng|k)/y/        # 容錯 yu -> y
     - derive/(g|k)u(?!ng|k)/$1wu/ # 輔音圓唇
     - derive/eoi(?=\d)/eoy/       # 容錯
     - derive/eo/oe/               # 容錯 eo/oe 不分

--- a/CantoboardFramework/Data/Rime/jyut6ping3vxq.schema.yaml
+++ b/CantoboardFramework/Data/Rime/jyut6ping3vxq.schema.yaml
@@ -81,8 +81,7 @@ speller:
     - derive/^(?=[aeiou])/q/      # 增加 q 表示喉塞
     - derive/^jy?([aeiou])/y$1/   # 容錯 je -> ye, jyu -> yu
     - derive/^jyu/ju/             # 容錯 jyu -> ju
-    - derive/yu/y/                # 容錯 jyu -> jy
-    - erase/y(ng|k)/              # y + ng/k 視作簡拼而非 jung/juk
+    - derive/yu(?!ng|k)/y/        # 容錯 yu -> y
     - derive/(g|k)u(?!ng|k)/$1wu/ # 輔音圓唇
     - derive/eoi(?=\d)/eoy/       # 容錯
     - derive/eo/oe/               # 容錯 eo/oe 不分


### PR DESCRIPTION
https://github.com/rime/rime-cantonese/commit/58c88d008803875249dd8a41525adff9f16833f6
It seems like Rime internally use `regex_match` (instead of `regex_search`) which matches the whole string, like Python's `fullmatch`.
Anyway this line is unnecessary with a lookahead.